### PR TITLE
Add simple parsing of ranch listener exists

### DIFF
--- a/src/raven_error_logger.erl
+++ b/src/raven_error_logger.erl
@@ -125,6 +125,21 @@ parse_message(error = Level, Pid, "Error in process " ++ _, [Name, Node, Reason]
 			{reason, Reason}
 		]}
 	]};
+parse_message(error = Level, Pid, "Ranch listener " ++ _, [Name, Protocol, RefPid, Reason]) ->
+	%% ranch connection terminated
+	{Exception, Stacktrace} = parse_reason(Reason),
+	{format_exit(Protocol, Name, Reason), [
+		{level, Level},
+		{exception, Exception},
+		{stacktrace, Stacktrace},
+		{extra, [
+			{name, Name},
+			{pid, Pid},
+			{ref_pid, RefPid},
+			{protocol, Protocol},
+			{reason, Reason}
+		]}
+	]};
 parse_message(Level, Pid, Format, Data) ->
 	{format(Format, Data), [
 		{level, Level},


### PR DESCRIPTION
I added simple parsing of ranch errors which ranch sends to logger from here: https://github.com/ninenines/ranch/blob/master/src/ranch_conns_sup.erl#L315

#TODO:
* add parsing of exceptions, now it isn't parsed correctly and add state to extra data