### PR TITLE
Raven improvements: async http, metadata configuration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,5 @@ ebin
 *.beam
 *.plt
 erl_crash.dump
+.*.sw?
+.rebar3

--- a/README.md
+++ b/README.md
@@ -37,13 +37,39 @@ Now all events logged using error_logger will be sent to the [Sentry](http://abo
 At the moment, the raven lager backend shares its configuration with the raven application, and does
 not allow per-backend configuration.
 
-To add the raven backend:
+### Simple Configuration
+
+This adds the raven backend to lager. By default, it configures the raven lager backend to send most metadata that the lager parse transform creates (see Advanced Configuration).
 
 ```erlang
 {lager, [
     {handlers, [
         {raven_lager_backend, info}]}]}
 ```
+
+### Advanced Configuration
+
+This configuration uses a list `[Level :: atom(), MetadataKeys :: [atom()]]`.
+
+`MetadataKeys` is a list of atoms that correspond to the metadata to be sent by Raven, should it be included in the lager log message.
+
+The configuration shown here is equivalent to the Simple Configuration.
+
+```erlang
+{lager, [
+    {handlers, [
+        {raven_lager_backend,
+            [info, [pid, file, line, module, function, stacktrace]]}]}]}
+```
+
+To exclude all metadata except `pid`:
+
+```erlang
+{lager, [
+    {handlers, [
+        {raven_lager_backend, [info, [pid]]}]}]}
+```
+
 
 ## Advanced Usage
 
@@ -55,7 +81,7 @@ raven:capture("Test Event", [
     {stacktrace, erlang:get_stacktrace()},
     {extra, [
         {pid, self()},
-        {process_dictionnary, erlang:get()}
+        {process_dictionary, erlang:get()}
     ]}
 ]).
 ```

--- a/src/raven.erl
+++ b/src/raven.erl
@@ -40,7 +40,7 @@ capture(Message, Params) when is_list(Message) ->
 	capture(unicode:characters_to_binary(Message), Params);
 capture(Message, Params0) ->
 	Cfg = get_config(),
-  Params1 = [{tags, get_tags()} | Params0],
+	Params1 = [{tags, get_tags()} | Params0],
 	Document = {[
 		{event_id, event_id_i()},
 		{project, unicode:characters_to_binary(Cfg#cfg.project)},
@@ -81,7 +81,7 @@ capture(Message, Params0) ->
 	httpc:request(post,
 		{Cfg#cfg.uri ++ "/api/store/", Headers, "application/octet-stream", Body},
 		[],
-		[{body_format, binary}]
+		[{body_format, binary}, {sync, false}, {receiver, fun(_) -> ok end}]
 	),
 	ok.
 
@@ -120,7 +120,7 @@ get_config(App) ->
 	end.
 
 get_tags() ->
-  application:get_env(?APP, tags, []).
+	application:get_env(?APP, tags, []).
 
 event_id_i() ->
 	U0 = crypto:rand_uniform(0, (2 bsl 32) - 1),

--- a/src/raven_lager_backend.erl
+++ b/src/raven_lager_backend.erl
@@ -5,26 +5,41 @@
 
 
 -export([
-	init/1,
-	code_change/3,
-	terminate/2,
-	handle_call/2,
-	handle_event/2,
-	handle_info/2
-]).
+         init/1,
+         code_change/3,
+         terminate/2,
+         handle_call/2,
+         handle_event/2,
+         handle_info/2
+        ]).
 
 
--record(state, {level}).
+-define(DEFAULT_METADATA_KEYS, [pid, file, line, module, function, stacktrace]).
 
-init(Level) ->
-    {ok, #state{level=lager_util:config_to_mask(Level)}}.
+-record(state, {level, metadata_keys=[]}).
 
+init([Level]) when is_atom(Level) ->
+    init(Level);
+init([Level, Metadata]) when is_atom(Level), is_list(Metadata) ->
+    case check_metadata(Metadata) of
+        ok ->
+            {ok, #state{
+                    level=lager_util:config_to_mask(Level),
+                    metadata_keys=Metadata
+                   }};
+        {error, Reason} ->
+            {error, {fatal, {bad_metadata, Reason}}}
+    end;
+init(Level) when is_atom(Level) ->
+    init([Level, ?DEFAULT_METADATA_KEYS]);
+init(_) ->
+    {error, {fatal, invalid_configuration}}.
 
 %% @private
 handle_call(get_loglevel, #state{level=Level} = State) ->
     {ok, Level, State};
 handle_call({set_loglevel, Level}, State) ->
-   try lager_util:config_to_mask(Level) of
+    try lager_util:config_to_mask(Level) of
         Levels ->
             {ok, ok, State#state{level=Levels}}
     catch
@@ -32,14 +47,14 @@ handle_call({set_loglevel, Level}, State) ->
             {ok, {error, bad_log_level}, State}
     end;
 handle_call(_, State) ->
-	{ok, ok, State}.
+    {ok, ok, State}.
 
 %% @private
 handle_event({log, Data},
-    #state{level=L} = State) ->
+             #state{level=L, metadata_keys=MetadataKeys} = State) ->
     case lager_util:is_loggable(Data, L, ?MODULE) of
         true ->
-            {Message, Params} = parse_message(Data),
+            {Message, Params} = parse_message(Data, MetadataKeys),
             raven:capture(Message, Params),
             {ok, State};
         false ->
@@ -50,30 +65,38 @@ handle_event(_Event, State) ->
 
 
 handle_info(_, State) ->
-	{ok, State}.
+    {ok, State}.
 
 code_change(_, State, _) ->
-	{ok, State}.
+    {ok, State}.
 
 terminate(_, _) ->
-	ok.
+    ok.
+
+%% @private
+check_metadata(Metadata) ->
+    case lists:all(fun(X) -> is_atom(X) end, Metadata) of
+        true ->
+            ok;
+        false ->
+            {error, metadata_must_be_atom}
+    end.
+
+parse_message(LagerMsg, MetadataKeys) when is_tuple(LagerMsg) andalso
+                                           element(1, LagerMsg) =:= lager_msg ->
+    Extra = parse_meta(lager_msg:metadata(LagerMsg), MetadataKeys),
+    {lager_msg:message(LagerMsg),
+     [{level, lager_msg:severity(LagerMsg)},
+      {extra, Extra}]}.
 
 
-%% TODO - check what other metadata can be sent to sentry
-parse_message({lager_msg, [], MetaData, Level, _, _Time, Message}) ->
-    Extra = parse_meta(MetaData),
-    {Message, [{level, Level},
-               {extra, Extra}]}.
-
-
-%% @doc at the moment this is just a passthrough -- what other metadata is out there?
-parse_meta(MetaData) ->
-    parse_meta(MetaData, []).
-
-parse_meta([], Acc) ->
-    Acc;
-parse_meta([{pid, Pid} = PidProp | Rest], Acc) when is_pid(Pid) ->
-    parse_meta(Rest, [PidProp | Acc]);
-parse_meta([{_, _} | Rest], Acc) ->
-    parse_meta(Rest, Acc).
+%% @doc Select metadata as defined in config.
+%%
+%% == Example ===
+%%
+%% ```
+%% {raven_lager_backend, {warning, [pid, stacktrace, module, line, hostname]}
+%% '''
+parse_meta(MetaData, MetadataKeys) ->
+    [Prop || {K, _}=Prop <- MetaData, lists:member(K, MetadataKeys)].
 


### PR DESCRIPTION
- Synchronous httpc requests are slow. Making them async speeds things up a great deal. At a later stage, if the volume of requests becomes so large that memory is an issue, backpressure can be added.
- Expand configuration of `raven_lager_backend` to include a list of metadata keys that should be included in the `extra` dict. This is more flexible than hard-coding the list of metadata to be included.