### PR TITLE
Error logger improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ In `rebar.config`:
 
 ```erlang
 {deps, [
-    {raven_erlang, "0.3.5"}
+    {raven_erlang, "0.3.7"}
 ]}.
 ```
 
@@ -32,31 +32,47 @@ To start `raven_erlang` with your application, add in your `myapp.app.src`:
 
 ## Configure
 
-The raven application itself needs to be configured using the application's environment, this is generally done in app.config or sys.config.
-
-It will accept either the individual config components:
+`raven_erlang` is configured using the application environment. This is generally done in app.config or sys.config:
 
 ```erlang
 {raven_erlang, [
+    % One can point `raven_erlang` to a project like this:
     {uri, "https://app.getsentry.com"},
     {project, "1"},
     {public_key, "PUBLIC_KEY"},
     {private_key, "PRIVATE_KEY"},
-    {error_logger, true},  % Set to true in order to install the standard error logger
-    {ipfamily, inet}  % Set to inet6 to use IPv6. See `ipfamily` in `httpc:set_options/1` for more information. Default to `inet` if no provided.
-]}.
-```
 
-or just the DSN:
-
-```erlang
-{raven_erlang, [
+    % ...or just use the DSN:
     {dsn, "https://PUBLIC_KEY:PRIVATE_KEY@app.getsentry.com/1"},
-    {error_logger, true}  % Set to true in order to install the standard error logger
+
+    % Set to inet6 to use IPv6.
+    % See `ipfamily` in `httpc:set_options/1` for more information.
+    % Default value is `inet`.
+    {ipfamily, inet},
+
+    % Set to true in order to install the standard error logger.
+    % Now all events logged using `error_logger` will be sent to Sentry.
+    {error_logger, true},
+
+    % Customize error logger:
+    % Default value is `[]`.
+    {error_logger_config, [
+        % `warning` or `error`.
+        % If set to `error`, error logger will ignore warning messages and reports.
+        % Default value is `warning`.
+        {level, warning},
+
+        % Not all messages that error_logger generates are useful.
+        % For example, supervisors will always generate an error_report when
+        % restarting a child, even if it exits with `reason = normal`.
+        % You can provide a module that implements `raven_error_logger_filter` behavior
+        % to avoid spamming sentry with issues that are not errors.
+        % See http://erlang.org/doc/apps/sasl/error_logging.html for more information.
+        % Default value is `undefined`.
+        {filter, callback_module}
+    ]}
 ]}.
 ```
-
-Now all events logged using error_logger will be sent to the [Sentry](http://aboutsentry.com/) service.
 
 ## Lager Backend
 

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ In `rebar.config`:
 
 ```erlang
 {deps, [
-    {raven_erlang, "0.3.7"}
+    {raven_erlang, "0.4.0"}
 ]}.
 ```
 

--- a/include/raven_error_logger.hrl
+++ b/include/raven_error_logger.hrl
@@ -1,14 +1,14 @@
 -type report_type() ::
-	crash_report |
-	supervisor_report |
-	progress |
-	std_error |
-	any(). % error_logger:error_report/2 can be called with any Type.
+    crash_report |
+    supervisor_report |
+    progress |
+    std_error |
+    any(). % error_logger:error_report/2 can be called with any Type.
 -type logging_level() :: warning | error.
 -type reason() :: any().
 -type supervisor() :: atom().
 -type supervisor_report_context() ::
-	start_error |
-	child_terminated |
-	shutdown_error.
+    start_error |
+    child_terminated |
+    shutdown_error.
 

--- a/include/raven_error_logger.hrl
+++ b/include/raven_error_logger.hrl
@@ -1,0 +1,14 @@
+-type report_type() ::
+	crash_report |
+	supervisor_report |
+	progress |
+	std_error |
+	any(). % error_logger:error_report/2 can be called with any Type.
+-type logging_level() :: warning | error.
+-type reason() :: any().
+-type supervisor() :: atom().
+-type supervisor_report_context() ::
+	start_error |
+	child_terminated |
+	shutdown_error.
+

--- a/src/raven.erl
+++ b/src/raven.erl
@@ -1,14 +1,14 @@
 -module(raven).
 -include("raven.hrl").
 -export([
-	start/0,
-	stop/0,
-	capture/2,
-	user_agent/0
+    start/0,
+    stop/0,
+    capture/2,
+    user_agent/0
 ]).
 -ifdef(TEST).
 -export([
-	get_config/0
+    get_config/0
 ]).
 -endif.
 
@@ -16,165 +16,165 @@
 -define(JSONE_OPTS, [native_utf8, {object_key_type, scalar}]).
 
 -record(cfg, {
-	uri :: string(),
-	public_key :: string(),
-	private_key :: string(),
-	project :: string(),
-	ipfamily :: atom()
+    uri :: string(),
+    public_key :: string(),
+    private_key :: string(),
+    project :: string(),
+    ipfamily :: atom()
 }).
 
 -type cfg_rec() :: #cfg{}.
 
 -spec start() -> ok | {error, term()}.
 start() ->
-	application:ensure_all_started(?APP).
+    application:ensure_all_started(?APP).
 
 -spec stop() -> ok | {error, term()}.
 stop() ->
-	application:stop(?APP).
+    application:stop(?APP).
 
 -spec capture(string() | binary(), [parameter()]) -> ok.
 -type parameter() ::
-	{stacktrace, [stackframe()]} |
-	{exception, {exit | error | throw, term()}} |
-	{atom(), binary() | integer()}.
+    {stacktrace, [stackframe()]} |
+    {exception, {exit | error | throw, term()}} |
+    {atom(), binary() | integer()}.
 -type stackframe() ::
-	{module(), atom(), non_neg_integer() | [term()]} |
-	{module(), atom(), non_neg_integer() | [term()], [{atom(), term()}]}.
+    {module(), atom(), non_neg_integer() | [term()]} |
+    {module(), atom(), non_neg_integer() | [term()], [{atom(), term()}]}.
 capture(Message, Params) when is_list(Message) ->
-	capture(unicode:characters_to_binary(Message), Params);
+    capture(unicode:characters_to_binary(Message), Params);
 capture(Message, Params0) ->
-	Cfg = get_config(),
-	Params1 = [{tags, get_tags()} | Params0],
-	Params2 = maybe_append_release(Params1),
-	Document = {[
-		{event_id, event_id_i()},
-		{project, unicode:characters_to_binary(Cfg#cfg.project)},
-		{platform, erlang},
-		{server_name, node()},
-		{timestamp, timestamp_i()},
-		{message, term_to_json_i(Message)} |
-		lists:map(fun
-			({stacktrace, Value}) ->
-				{'sentry.interfaces.Stacktrace', {[
-					{frames,lists:reverse([frame_to_json_i(Frame) || Frame <- Value])}
-				]}};
-			({exception, {Type, Value}}) ->
-				{'sentry.interfaces.Exception', {[
-					{type, Type},
-					{value, term_to_json_i(Value)}
-				]}};
-			({tags, Tags}) ->
-				{tags, {[{Key, term_to_json_i(Value)} || {Key, Value} <- Tags]}};
-			({extra, Tags}) ->
-				{extra, {[{Key, term_to_json_i(Value)} || {Key, Value} <- Tags]}};
-			({Key, Value}) ->
-				{Key, term_to_json_i(Value)}
-		end, Params2)
-	]},
-	Timestamp = integer_to_list(unix_timestamp_i()),
-	Body = base64:encode(zlib:compress(jsone:encode(Document, ?JSONE_OPTS))),
-	UA = user_agent(),
-	Headers = [
-		{"X-Sentry-Auth",
-		["Sentry sentry_version=", ?SENTRY_VERSION,
-		 ",sentry_client=", UA,
-		 ",sentry_timestamp=", Timestamp,
-		 ",sentry_key=", Cfg#cfg.public_key]},
-		{"User-Agent", UA}
-	],
-	ok = httpc:set_options([{ipfamily, Cfg#cfg.ipfamily}]),
-	httpc:request(post,
-		{Cfg#cfg.uri ++ "/api/store/", Headers, "application/octet-stream", Body},
-		[],
-		[{body_format, binary}, {sync, false}, {receiver, fun(_) -> ok end}]
-	),
-	ok.
+    Cfg = get_config(),
+    Params1 = [{tags, get_tags()} | Params0],
+    Params2 = maybe_append_release(Params1),
+    Document = {[
+        {event_id, event_id_i()},
+        {project, unicode:characters_to_binary(Cfg#cfg.project)},
+        {platform, erlang},
+        {server_name, node()},
+        {timestamp, timestamp_i()},
+        {message, term_to_json_i(Message)} |
+        lists:map(fun
+            ({stacktrace, Value}) ->
+                {'sentry.interfaces.Stacktrace', {[
+                    {frames,lists:reverse([frame_to_json_i(Frame) || Frame <- Value])}
+                ]}};
+            ({exception, {Type, Value}}) ->
+                {'sentry.interfaces.Exception', {[
+                    {type, Type},
+                    {value, term_to_json_i(Value)}
+                ]}};
+            ({tags, Tags}) ->
+                {tags, {[{Key, term_to_json_i(Value)} || {Key, Value} <- Tags]}};
+            ({extra, Tags}) ->
+                {extra, {[{Key, term_to_json_i(Value)} || {Key, Value} <- Tags]}};
+            ({Key, Value}) ->
+                {Key, term_to_json_i(Value)}
+        end, Params2)
+    ]},
+    Timestamp = integer_to_list(unix_timestamp_i()),
+    Body = base64:encode(zlib:compress(jsone:encode(Document, ?JSONE_OPTS))),
+    UA = user_agent(),
+    Headers = [
+        {"X-Sentry-Auth",
+        ["Sentry sentry_version=", ?SENTRY_VERSION,
+         ",sentry_client=", UA,
+         ",sentry_timestamp=", Timestamp,
+         ",sentry_key=", Cfg#cfg.public_key]},
+        {"User-Agent", UA}
+    ],
+    ok = httpc:set_options([{ipfamily, Cfg#cfg.ipfamily}]),
+    httpc:request(post,
+        {Cfg#cfg.uri ++ "/api/store/", Headers, "application/octet-stream", Body},
+        [],
+        [{body_format, binary}, {sync, false}, {receiver, fun(_) -> ok end}]
+    ),
+    ok.
 
 -spec user_agent() -> iolist().
 user_agent() ->
-	{ok, Vsn} = application:get_key(?APP, vsn),
-	["raven-erlang/", Vsn].
+    {ok, Vsn} = application:get_key(?APP, vsn),
+    ["raven-erlang/", Vsn].
 
 %% @private
 -spec get_config() -> cfg_rec().
 get_config() ->
-	get_config(?APP).
+    get_config(?APP).
 
 -spec get_config(App :: atom()) -> cfg_rec().
 get_config(App) ->
-	IpFamily = application:get_env(App, ipfamily, inet),
-	case application:get_env(App, dsn) of
-		{ok, Dsn} ->
-			{match, [_, Protocol, PublicKey, SecretKey, Uri, Project]} =
-				re:run(Dsn, "^(https?://)(.+):(.+)@(.+)/(.+)$", [{capture, all, list}]),
-			#cfg{uri = Protocol ++ Uri,
-			     public_key = PublicKey,
-			     private_key = SecretKey,
-			     project = Project,
-			     ipfamily = IpFamily};
-		undefined ->
-			{ok, Uri} = application:get_env(App, uri),
-			{ok, PublicKey} = application:get_env(App, public_key),
-			{ok, PrivateKey} = application:get_env(App, private_key),
-			{ok, Project} = application:get_env(App, project),
-			#cfg{uri = Uri,
-			     public_key = PublicKey,
-			     private_key = PrivateKey,
-			     project = Project,
-			     ipfamily = IpFamily}
-	end.
+    IpFamily = application:get_env(App, ipfamily, inet),
+    case application:get_env(App, dsn) of
+        {ok, Dsn} ->
+            {match, [_, Protocol, PublicKey, SecretKey, Uri, Project]} =
+                re:run(Dsn, "^(https?://)(.+):(.+)@(.+)/(.+)$", [{capture, all, list}]),
+            #cfg{uri = Protocol ++ Uri,
+                 public_key = PublicKey,
+                 private_key = SecretKey,
+                 project = Project,
+                 ipfamily = IpFamily};
+        undefined ->
+            {ok, Uri} = application:get_env(App, uri),
+            {ok, PublicKey} = application:get_env(App, public_key),
+            {ok, PrivateKey} = application:get_env(App, private_key),
+            {ok, Project} = application:get_env(App, project),
+            #cfg{uri = Uri,
+                 public_key = PublicKey,
+                 private_key = PrivateKey,
+                 project = Project,
+                 ipfamily = IpFamily}
+    end.
 
 get_tags() ->
-	application:get_env(?APP, tags, []).
+    application:get_env(?APP, tags, []).
 
 maybe_append_release(Params) ->
-	case application:get_env(?APP, release) of
-		{ok, Release} -> [{release, Release} | Params];
-		undefined -> Params
-	end.
+    case application:get_env(?APP, release) of
+        {ok, Release} -> [{release, Release} | Params];
+        undefined -> Params
+    end.
 
 event_id_i() ->
-	<<U0:32, U1:16, _:4, U2:12, _:2, U3:30, U4:32>> = crypto:strong_rand_bytes(16),
-	<<UUID:128>> = <<U0:32, U1:16, 4:4, U2:12, 2#10:2, U3:30, U4:32>>,
-	iolist_to_binary(io_lib:format("~32.16.0b", [UUID])).
+    <<U0:32, U1:16, _:4, U2:12, _:2, U3:30, U4:32>> = crypto:strong_rand_bytes(16),
+    <<UUID:128>> = <<U0:32, U1:16, 4:4, U2:12, 2#10:2, U3:30, U4:32>>,
+    iolist_to_binary(io_lib:format("~32.16.0b", [UUID])).
 
 timestamp_i() ->
-	{{Y,Mo,D}, {H,Mn,S}} = calendar:now_to_datetime(os:timestamp()),
-	FmtStr = "~4.10.0B-~2.10.0B-~2.10.0BT~2.10.0B:~2.10.0B:~2.10.0B",
-	iolist_to_binary(io_lib:format(FmtStr, [Y, Mo, D, H, Mn, S])).
+    {{Y,Mo,D}, {H,Mn,S}} = calendar:now_to_datetime(os:timestamp()),
+    FmtStr = "~4.10.0B-~2.10.0B-~2.10.0BT~2.10.0B:~2.10.0B:~2.10.0B",
+    iolist_to_binary(io_lib:format(FmtStr, [Y, Mo, D, H, Mn, S])).
 
 unix_timestamp_i() ->
-	{Mega, Sec, Micro} = os:timestamp(),
-	Mega * 1000000 * 1000000 + Sec * 1000000 + Micro.
+    {Mega, Sec, Micro} = os:timestamp(),
+    Mega * 1000000 * 1000000 + Sec * 1000000 + Micro.
 
 frame_to_json_i({Module, Function, Arguments}) ->
-	frame_to_json_i({Module, Function, Arguments, []});
+    frame_to_json_i({Module, Function, Arguments, []});
 frame_to_json_i({Module, Function, Arguments, Location}) ->
-	Arity = case is_list(Arguments) of
-		true -> length(Arguments);
-		false -> Arguments
-	end,
-	Line = case lists:keyfind(line, 1, Location) of
-		false -> -1;
-		{line, L} -> L
-	end,
-	{
-		case is_list(Arguments) of
-			true -> [{vars, [iolist_to_binary(io_lib:format("~w", [Argument])) || Argument <- Arguments]}];
-			false -> []
-		end ++ [
-			{module, Module},
-			{function, <<(atom_to_binary(Function, utf8))/binary, "/", (list_to_binary(integer_to_list(Arity)))/binary>>},
-			{lineno, Line},
-			{filename, case lists:keyfind(file, 1, Location) of
-				false -> <<(atom_to_binary(Module, utf8))/binary, ".erl">>;
-				{file, File} -> list_to_binary(File)
-			end}
-		]
-	}.
+    Arity = case is_list(Arguments) of
+        true -> length(Arguments);
+        false -> Arguments
+    end,
+    Line = case lists:keyfind(line, 1, Location) of
+        false -> -1;
+        {line, L} -> L
+    end,
+    {
+        case is_list(Arguments) of
+            true -> [{vars, [iolist_to_binary(io_lib:format("~w", [Argument])) || Argument <- Arguments]}];
+            false -> []
+        end ++ [
+            {module, Module},
+            {function, <<(atom_to_binary(Function, utf8))/binary, "/", (list_to_binary(integer_to_list(Arity)))/binary>>},
+            {lineno, Line},
+            {filename, case lists:keyfind(file, 1, Location) of
+                false -> <<(atom_to_binary(Module, utf8))/binary, ".erl">>;
+                {file, File} -> list_to_binary(File)
+            end}
+        ]
+    }.
 
 term_to_json_i(Term) when is_binary(Term); is_atom(Term) ->
-	Term;
+    Term;
 term_to_json_i(Term) ->
-	iolist_to_binary(io_lib:format("~120p", [Term])).
+    iolist_to_binary(io_lib:format("~120p", [Term])).

--- a/src/raven_app.erl
+++ b/src/raven_app.erl
@@ -2,26 +2,26 @@
 -include("raven.hrl").
 -behaviour(application).
 -export([
-	start/2,
-	stop/1
+    start/2,
+    stop/1
 ]).
 
 %% @hidden
 start(_StartType, _StartArgs) ->
-		case application:get_env(?APP, error_logger) of
-			{ok, true} ->
-				error_logger:add_report_handler(raven_error_logger);
-			_ ->
-				ok
-		end,
-		raven_sup:start_link().
+        case application:get_env(?APP, error_logger) of
+            {ok, true} ->
+                error_logger:add_report_handler(raven_error_logger);
+            _ ->
+                ok
+        end,
+        raven_sup:start_link().
 
 %% @hidden
 stop(_State) ->
-	case application:get_env(?APP, error_logger) of
-		{ok, true} ->
-			error_logger:delete_report_handler(raven_error_logger),
-			ok;
-		_ ->
-			ok
-	end.
+    case application:get_env(?APP, error_logger) of
+        {ok, true} ->
+            error_logger:delete_report_handler(raven_error_logger),
+            ok;
+        _ ->
+            ok
+    end.

--- a/src/raven_erlang.app.src
+++ b/src/raven_erlang.app.src
@@ -1,6 +1,6 @@
 {application, raven_erlang,
     [ {description, "Erlang client for Sentry"}
-    , {vsn, "0.3.7"}
+    , {vsn, "0.4.0"}
     , {registered, []}
     , {applications, [kernel, stdlib, crypto, public_key, ssl, inets, jsone]}
     , {mod, {raven_app, []}}

--- a/src/raven_erlang.app.src
+++ b/src/raven_erlang.app.src
@@ -1,6 +1,6 @@
 {application, raven_erlang,
 	[ {description, "Erlang client for Sentry"}
-	, {vsn, "0.3.6"}
+	, {vsn, "0.3.7"}
 	, {registered, []}
 	, {applications, [kernel, stdlib, crypto, public_key, ssl, inets, jsone]}
 	, {mod, {raven_app, []}}

--- a/src/raven_erlang.app.src
+++ b/src/raven_erlang.app.src
@@ -1,16 +1,16 @@
 {application, raven_erlang,
-	[ {description, "Erlang client for Sentry"}
-	, {vsn, "0.3.7"}
-	, {registered, []}
-	, {applications, [kernel, stdlib, crypto, public_key, ssl, inets, jsone]}
-	, {mod, {raven_app, []}}
-	, {env,
-			[ {error_logger, false}
-			, {ipfamily, inet}
-			]}
+    [ {description, "Erlang client for Sentry"}
+    , {vsn, "0.3.7"}
+    , {registered, []}
+    , {applications, [kernel, stdlib, crypto, public_key, ssl, inets, jsone]}
+    , {mod, {raven_app, []}}
+    , {env,
+            [ {error_logger, false}
+            , {ipfamily, inet}
+            ]}
 
-	, {pkg_name, raven_erlang}
-	, {licenses, ["MIT"]}
-	, {maintainers, ["Ali Sabil", "Yuri Artemev"]}
-	, {links, [{"Github", "https://github.com/artemeff/raven-erlang"}]}
-	]}.
+    , {pkg_name, raven_erlang}
+    , {licenses, ["MIT"]}
+    , {maintainers, ["Ali Sabil", "Yuri Artemev"]}
+    , {links, [{"Github", "https://github.com/artemeff/raven-erlang"}]}
+    ]}.

--- a/src/raven_error_logger.erl
+++ b/src/raven_error_logger.erl
@@ -3,382 +3,382 @@
 -include("raven_error_logger.hrl").
 -behaviour(gen_event).
 -export([
-	init/1,
-	code_change/3,
-	terminate/2,
-	handle_call/2,
-	handle_event/2,
-	handle_info/2
+    init/1,
+    code_change/3,
+    terminate/2,
+    handle_call/2,
+    handle_event/2,
+    handle_info/2
 ]).
 
 -record(config, {
-	logging_level = warning :: logging_level(),
-	filter = undefined :: module()
+    logging_level = warning :: logging_level(),
+    filter = undefined :: module()
 }).
 
 init(_) ->
-	{ok, []}.
+    {ok, []}.
 
 handle_call(_, State) ->
-	{ok, ok, State}.
+    {ok, ok, State}.
 
 handle_event({error, _, {Pid, Format, Data}}, State) ->
-	{Message, Details} = parse_message(error, Pid, Format, Data),
-	raven:capture(Message, Details),
-	{ok, State};
+    {Message, Details} = parse_message(error, Pid, Format, Data),
+    raven:capture(Message, Details),
+    {ok, State};
 handle_event({error_report, _, {Pid, Type, Report}}, State) ->
-	case should_send_report(Type, Report) of
-		true ->
-			{Message, Details} = parse_report(error, Pid, Type, Report),
-			raven:capture(Message, Details),
-			{ok, State};
-		false ->
-			{ok, State}
-	end;
+    case should_send_report(Type, Report) of
+        true ->
+            {Message, Details} = parse_report(error, Pid, Type, Report),
+            raven:capture(Message, Details),
+            {ok, State};
+        false ->
+            {ok, State}
+    end;
 
 handle_event({warning_msg, _, {Pid, Format, Data}}, State) ->
-	case get_config() of
-		#config{logging_level = warning} ->
-			{Message, Details} = parse_message(warning, Pid, Format, Data),
-			raven:capture(Message, Details),
-			{ok, State};
-		_ ->
-			{ok, State}
-	end;
+    case get_config() of
+        #config{logging_level = warning} ->
+            {Message, Details} = parse_message(warning, Pid, Format, Data),
+            raven:capture(Message, Details),
+            {ok, State};
+        _ ->
+            {ok, State}
+    end;
 handle_event({warning_report, _, {Pid, Type, Report}}, State) ->
-	case {get_config(), should_send_report(Type, Report)} of
-		{#config{logging_level = warning}, true}->
-			{Message, Details} = parse_report(warning, Pid, Type, Report),
-			raven:capture(Message, Details),
-			{ok, State};
-		_ ->
-			{ok, State}
-	end;
+    case {get_config(), should_send_report(Type, Report)} of
+        {#config{logging_level = warning}, true}->
+            {Message, Details} = parse_report(warning, Pid, Type, Report),
+            raven:capture(Message, Details),
+            {ok, State};
+        _ ->
+            {ok, State}
+    end;
 
 handle_event(_, State) ->
-	{ok, State}.
+    {ok, State}.
 
 handle_info(_, State) ->
-	{ok, State}.
+    {ok, State}.
 
 code_change(_, State, _) ->
-	{ok, State}.
+    {ok, State}.
 
 terminate(_, _) ->
-	ok.
+    ok.
 
 
 %% @private
 -spec get_config() -> #config{}.
 get_config() ->
-	Default = #config{},
-	case application:get_env(?APP, error_logger_config) of
-		{ok, Options} when is_list(Options) ->
-			#config{
-				logging_level =
-					proplists:get_value(level,
-										Options,
-										Default#config.logging_level),
-				filter =
-					proplists:get_value(filter,
-										Options,
-										Default#config.filter)
-			};
-		undefined ->
-			Default
-	end.
+    Default = #config{},
+    case application:get_env(?APP, error_logger_config) of
+        {ok, Options} when is_list(Options) ->
+            #config{
+                logging_level =
+                    proplists:get_value(level,
+                                        Options,
+                                        Default#config.logging_level),
+                filter =
+                    proplists:get_value(filter,
+                                        Options,
+                                        Default#config.filter)
+            };
+        undefined ->
+            Default
+    end.
 
 
 %% @private
 parse_message(error = Level, Pid, "** Generic server " ++ _, [Name, LastMessage, State, Reason]) ->
-	%% gen_server terminate
-	{Exception, Stacktrace} = parse_reason(Reason),
-	{format_exit(gen_server, Name, Reason), [
-		{level, Level},
-		{exception, Exception},
-		{stacktrace, Stacktrace},
-		{extra, [
-			{name, Name},
-			{pid, Pid},
-			{last_message, LastMessage},
-			{state, State},
-			{reason, Reason}
-		]}
-	]};
+    %% gen_server terminate
+    {Exception, Stacktrace} = parse_reason(Reason),
+    {format_exit(gen_server, Name, Reason), [
+        {level, Level},
+        {exception, Exception},
+        {stacktrace, Stacktrace},
+        {extra, [
+            {name, Name},
+            {pid, Pid},
+            {last_message, LastMessage},
+            {state, State},
+            {reason, Reason}
+        ]}
+    ]};
 parse_message(error = Level, Pid, "** State machine " ++ _, [Name, LastMessage, StateName, State, Reason]) ->
-	%% gen_fsm terminate
-	{Exception, Stacktrace} = parse_reason(Reason),
-	{format_exit(gen_fsm, Name, Reason), [
-		{level, Level},
-		{exception, Exception},
-		{stacktrace, Stacktrace},
-		{extra, [
-			{name, Name},
-			{pid, Pid},
-			{last_message, LastMessage},
-			{state, State},
-			{state_name, StateName},
-			{reason, Reason}
-		]}
-	]};
+    %% gen_fsm terminate
+    {Exception, Stacktrace} = parse_reason(Reason),
+    {format_exit(gen_fsm, Name, Reason), [
+        {level, Level},
+        {exception, Exception},
+        {stacktrace, Stacktrace},
+        {extra, [
+            {name, Name},
+            {pid, Pid},
+            {last_message, LastMessage},
+            {state, State},
+            {state_name, StateName},
+            {reason, Reason}
+        ]}
+    ]};
 parse_message(error = Level, Pid, "** gen_event handler " ++ _, [ID, Name, LastMessage, State, Reason]) ->
-	%% gen_event terminate
-	{Exception, Stacktrace} = parse_reason(Reason),
-	{format_exit(gen_event, Name, Reason), [
-		{level, Level},
-		{exception, Exception},
-		{stacktrace, Stacktrace},
-		{extra, [
-			{id, ID},
-			{name, Name},
-			{pid, Pid},
-			{last_message, LastMessage},
-			{state, State},
-			{reason, Reason}
-		]}
-	]};
+    %% gen_event terminate
+    {Exception, Stacktrace} = parse_reason(Reason),
+    {format_exit(gen_event, Name, Reason), [
+        {level, Level},
+        {exception, Exception},
+        {stacktrace, Stacktrace},
+        {extra, [
+            {id, ID},
+            {name, Name},
+            {pid, Pid},
+            {last_message, LastMessage},
+            {state, State},
+            {reason, Reason}
+        ]}
+    ]};
 parse_message(error = Level, Pid, "** Generic process " ++ _, [Name, LastMessage, State, Reason]) ->
-	%% gen_process terminate
-	{Exception, Stacktrace} = parse_reason(Reason),
-	{format_exit(gen_process, Name, Reason), [
-		{level, Level},
-		{exception, Exception},
-		{stacktrace, Stacktrace},
-		{extra, [
-			{name, Name},
-			{pid, Pid},
-			{last_message, LastMessage},
-			{state, State},
-			{reason, Reason}
-		]}
-	]};
+    %% gen_process terminate
+    {Exception, Stacktrace} = parse_reason(Reason),
+    {format_exit(gen_process, Name, Reason), [
+        {level, Level},
+        {exception, Exception},
+        {stacktrace, Stacktrace},
+        {extra, [
+            {name, Name},
+            {pid, Pid},
+            {last_message, LastMessage},
+            {state, State},
+            {reason, Reason}
+        ]}
+    ]};
 parse_message(error = Level, Pid, "Error in process " ++ _, [Name, Node, Reason]) ->
-	%% process terminate
-	{Exception, Stacktrace} = parse_reason(Reason),
-	{format_exit(process, Name, Reason), [
-		{level, Level},
-		{exception, Exception},
-		{stacktrace, Stacktrace},
-		{extra, [
-			{name, Name},
-			{pid, Pid},
-			{node, Node},
-			{reason, Reason}
-		]}
-	]};
+    %% process terminate
+    {Exception, Stacktrace} = parse_reason(Reason),
+    {format_exit(process, Name, Reason), [
+        {level, Level},
+        {exception, Exception},
+        {stacktrace, Stacktrace},
+        {extra, [
+            {name, Name},
+            {pid, Pid},
+            {node, Node},
+            {reason, Reason}
+        ]}
+    ]};
 parse_message(error = Level, Pid, "Ranch listener " ++ _, [Name, Protocol, RefPid, Reason]) ->
-	%% ranch connection terminated
-	{Exception, Stacktrace} = parse_reason(Reason),
-	{format_exit(Protocol, Name, Reason), [
-		{level, Level},
-		{exception, Exception},
-		{stacktrace, Stacktrace},
-		{extra, [
-			{name, Name},
-			{pid, Pid},
-			{ref_pid, RefPid},
-			{protocol, Protocol},
-			{reason, Reason}
-		]}
-	]};
+    %% ranch connection terminated
+    {Exception, Stacktrace} = parse_reason(Reason),
+    {format_exit(Protocol, Name, Reason), [
+        {level, Level},
+        {exception, Exception},
+        {stacktrace, Stacktrace},
+        {extra, [
+            {name, Name},
+            {pid, Pid},
+            {ref_pid, RefPid},
+            {protocol, Protocol},
+            {reason, Reason}
+        ]}
+    ]};
 parse_message(error = Level, Pid, "** Task " ++ _, [TaskPid, RefPid, Fun, FunArgs, Reason]) ->
   {Exception, Stacktrace} = parse_reason(Reason),
-	{format_exit("Task", TaskPid, Reason), [
-		{level, Level},
-		{exception, Exception},
-		{stacktrace, Stacktrace},
-		{extra, [
-			{pid, Pid},
-			{parent_pid, RefPid},
-			{function, Fun},
-			{function_args, FunArgs}
-		]}
-	]};
+    {format_exit("Task", TaskPid, Reason), [
+        {level, Level},
+        {exception, Exception},
+        {stacktrace, Stacktrace},
+        {extra, [
+            {pid, Pid},
+            {parent_pid, RefPid},
+            {function, Fun},
+            {function_args, FunArgs}
+        ]}
+    ]};
 parse_message(Level, Pid, Format, Data) ->
-	{format(Format, Data), [
-		{level, Level},
-		{extra, [
-			{pid, Pid},
-			{data, Data}
-		]}
-	]}.
+    {format(Format, Data), [
+        {level, Level},
+        {extra, [
+            {pid, Pid},
+            {data, Data}
+        ]}
+    ]}.
 
 
 %% @private
 -spec should_send_report(report_type(), error_logger:report()) -> boolean().
 should_send_report(supervisor_report, Report) ->
-	[{errorContext, Context},
-	 {offender, _},
-	 {reason, Reason},
-	 {supervisor, Supervisor}] = lists:sort(Report),
-	#config{
-		filter = Mod
-	} = get_config(),
-	case erlang:function_exported(Mod, should_send_supervisor_report, 3) of
-		true ->
-			Mod:should_send_supervisor_report(Supervisor, Reason, Context);
-		false ->
-			true
-	end;
+    [{errorContext, Context},
+     {offender, _},
+     {reason, Reason},
+     {supervisor, Supervisor}] = lists:sort(Report),
+    #config{
+        filter = Mod
+    } = get_config(),
+    case erlang:function_exported(Mod, should_send_supervisor_report, 3) of
+        true ->
+            Mod:should_send_supervisor_report(Supervisor, Reason, Context);
+        false ->
+            true
+    end;
 should_send_report(_, _) -> true.
 
 
 %% @private
 parse_report(Level, Pid, Type, Report) ->
-	case {Level, Type} of
-		{_, crash_report} when is_list(Report) ->
-			parse_crash_report(Level, Pid, lists:sort(Report));
-		{_, supervisor_report} when is_list(Report) ->
-			parse_supervisor_report(Level, Pid, lists:sort(Report));
-		{info, progress} when is_list(Report) ->
-			parse_progress_report(Pid, lists:sort(Report));
-		{error, std_error} when is_list(Report) ->
-			parse_std_error_report(Pid, Report);
-		_ ->
-			parse_unknown_report(Level, Pid, Type, Report)
-	end.
+    case {Level, Type} of
+        {_, crash_report} when is_list(Report) ->
+            parse_crash_report(Level, Pid, lists:sort(Report));
+        {_, supervisor_report} when is_list(Report) ->
+            parse_supervisor_report(Level, Pid, lists:sort(Report));
+        {info, progress} when is_list(Report) ->
+            parse_progress_report(Pid, lists:sort(Report));
+        {error, std_error} when is_list(Report) ->
+            parse_std_error_report(Pid, Report);
+        _ ->
+            parse_unknown_report(Level, Pid, Type, Report)
+    end.
 
 
 %% @private
 parse_crash_report(Level, Pid, [Report, Neighbors]) ->
-	Name = case proplists:get_value(registered_name, Report, []) of
-		[] -> proplists:get_value(pid, Report);
-		N -> N
-	end,
-	case Name of
-		undefined ->
-			{<<"Process crashed">>, [
-				{level, Level},
-				{extra, [
-					{pid, Pid},
-					{neighbors, Neighbors} |
-					Report
-				]}
-			]};
-		_ ->
-			{Class, R, Trace} = proplists:get_value(error_info, Report, {error, unknown, []}),
-			Reason = {{Class, R}, Trace},
-			{Exception, Stacktrace} = parse_reason(Reason),
-			{format_exit("Process", Name, Reason), [
-				{level, Level},
-				{exception, Exception},
-				{stacktrace, Stacktrace},
-				{extra, [
-					{name, Name},
-					{pid, Pid},
-					{reason, Reason} |
-					Report
-				]}
-			]}
-	end.
+    Name = case proplists:get_value(registered_name, Report, []) of
+        [] -> proplists:get_value(pid, Report);
+        N -> N
+    end,
+    case Name of
+        undefined ->
+            {<<"Process crashed">>, [
+                {level, Level},
+                {extra, [
+                    {pid, Pid},
+                    {neighbors, Neighbors} |
+                    Report
+                ]}
+            ]};
+        _ ->
+            {Class, R, Trace} = proplists:get_value(error_info, Report, {error, unknown, []}),
+            Reason = {{Class, R}, Trace},
+            {Exception, Stacktrace} = parse_reason(Reason),
+            {format_exit("Process", Name, Reason), [
+                {level, Level},
+                {exception, Exception},
+                {stacktrace, Stacktrace},
+                {extra, [
+                    {name, Name},
+                    {pid, Pid},
+                    {reason, Reason} |
+                    Report
+                ]}
+            ]}
+    end.
 
 
 %% @private
 parse_supervisor_report(Level, Pid, [{errorContext, Context}, {offender, Offender}, {reason, Reason}, {supervisor, Supervisor}]) ->
-	{Exception, Stacktrace} = parse_reason(Reason),
-	{format("Supervisor ~s had child exit with reason ~s", [format_name(Supervisor), format_reason(Reason)]), [
-		{level, Level},
-		{logger, supervisors},
-		{exception, Exception},
-		{stacktrace, Stacktrace},
-		{extra, [
-			{supervisor, Supervisor},
-			{context, Context},
-			{pid, Pid},
-			{child_pid, proplists:get_value(pid, Offender)},
-			{mfa, format_mfa(proplists:get_value(mfargs, Offender))},
-			{restart_type, proplists:get_value(restart_type, Offender)},
-			{child_type, proplists:get_value(child_type, Offender)},
-			{shutdown, proplists:get_value(shutdown, Offender)}
-		]}
-	]}.
+    {Exception, Stacktrace} = parse_reason(Reason),
+    {format("Supervisor ~s had child exit with reason ~s", [format_name(Supervisor), format_reason(Reason)]), [
+        {level, Level},
+        {logger, supervisors},
+        {exception, Exception},
+        {stacktrace, Stacktrace},
+        {extra, [
+            {supervisor, Supervisor},
+            {context, Context},
+            {pid, Pid},
+            {child_pid, proplists:get_value(pid, Offender)},
+            {mfa, format_mfa(proplists:get_value(mfargs, Offender))},
+            {restart_type, proplists:get_value(restart_type, Offender)},
+            {child_type, proplists:get_value(child_type, Offender)},
+            {shutdown, proplists:get_value(shutdown, Offender)}
+        ]}
+    ]}.
 
 
 %% @private
 parse_progress_report(Pid, [{started, Started}, {supervisor, Supervisor}]) ->
-	Message = case proplists:get_value(name, Started, []) of
-		[] -> format("Supervisor ~s started child", [format_name(Supervisor)]);
-		Name -> format("Supervisor ~s started ~s", [format_name(Supervisor), format_name(Name)])
-	end,
-	{Message, [
-		{level, info},
-		{logger, supervisors},
-		{extra, [
-			{supervisor, Supervisor},
-			{pid, Pid},
-			{child_pid, proplists:get_value(pid, Started)},
-			{mfa, format_mfa(proplists:get_value(mfargs, Started))},
-			{restart_type, proplists:get_value(restart_type, Started)},
-			{child_type, proplists:get_value(child_type, Started)},
-			{shutdown, proplists:get_value(shutdown, Started)}
-		]}
-	]}.
+    Message = case proplists:get_value(name, Started, []) of
+        [] -> format("Supervisor ~s started child", [format_name(Supervisor)]);
+        Name -> format("Supervisor ~s started ~s", [format_name(Supervisor), format_name(Name)])
+    end,
+    {Message, [
+        {level, info},
+        {logger, supervisors},
+        {extra, [
+            {supervisor, Supervisor},
+            {pid, Pid},
+            {child_pid, proplists:get_value(pid, Started)},
+            {mfa, format_mfa(proplists:get_value(mfargs, Started))},
+            {restart_type, proplists:get_value(restart_type, Started)},
+            {child_type, proplists:get_value(child_type, Started)},
+            {shutdown, proplists:get_value(shutdown, Started)}
+        ]}
+    ]}.
 
 
 %% @private
 parse_std_error_report(Pid, Report) ->
-	Message = case proplists:get_value(message, Report) of
-		undefined -> format_string(Report);
-		M -> format_string(M)
-	end,
-	{Toplevel, Extra} = lists:partition(fun
-		({exception, _}) -> true;
-		({stacktrace, _}) -> true;
-		(_) -> false
-	end, Report),
-	{Message, [
-		{level, error},
-		{extra, [
-			{type, std_error},
-			{pid, Pid} |
-			lists:keydelete(message, 1, Extra)
-		]} |
-		Toplevel
-	]}.
+    Message = case proplists:get_value(message, Report) of
+        undefined -> format_string(Report);
+        M -> format_string(M)
+    end,
+    {Toplevel, Extra} = lists:partition(fun
+        ({exception, _}) -> true;
+        ({stacktrace, _}) -> true;
+        (_) -> false
+    end, Report),
+    {Message, [
+        {level, error},
+        {extra, [
+            {type, std_error},
+            {pid, Pid} |
+            lists:keydelete(message, 1, Extra)
+        ]} |
+        Toplevel
+    ]}.
 
 
 %% @private
 parse_unknown_report(Level, Pid, Type, Report) ->
   Message = format_string(Report),
-	{Message, [
-		{level, Level},
-		{extra, [
-			{type, Type},
-			{pid, Pid}
-		]}
-	]}.
+    {Message, [
+        {level, Level},
+        {extra, [
+            {type, Type},
+            {pid, Pid}
+        ]}
+    ]}.
 
 
 %% @private
 parse_reason({'function not exported', Stacktrace}) ->
-	{{exit, undef}, parse_stacktrace(Stacktrace)};
+    {{exit, undef}, parse_stacktrace(Stacktrace)};
 parse_reason({bad_return, {_MFA, {'EXIT', Reason}}}) ->
-	parse_reason(Reason);
+    parse_reason(Reason);
 parse_reason({bad_return, {MFA, Value}}) ->
-	{{exit, {bad_return, Value}}, parse_stacktrace(MFA)};
+    {{exit, {bad_return, Value}}, parse_stacktrace(MFA)};
 parse_reason({bad_return_value, Value}) ->
-	{{exit, {bad_return, Value}}, []};
+    {{exit, {bad_return, Value}}, []};
 parse_reason({{bad_return_value, Value}, MFA}) ->
-	{{exit, {bad_return, Value}}, parse_stacktrace(MFA)};
+    {{exit, {bad_return, Value}}, parse_stacktrace(MFA)};
 parse_reason({badarg, Stacktrace}) ->
-	{{error, badarg}, parse_stacktrace(Stacktrace)};
+    {{error, badarg}, parse_stacktrace(Stacktrace)};
 parse_reason({{badmatch, Value}, Stacktrace}) ->
   {{exit, {badmatch, Value}}, parse_stacktrace(Stacktrace)};
 parse_reason({'EXIT', Reason}) ->
-	parse_reason(Reason);
+    parse_reason(Reason);
 parse_reason({Reason, Child}) when is_tuple(Child) andalso element(1, Child) =:= child ->
-	parse_reason(Reason);
+    parse_reason(Reason);
 parse_reason({{Class, Reason}, Stacktrace}) when Class =:= exit; Class =:= error; Class =:= throw ->
-	{{Class, Reason}, parse_stacktrace(Stacktrace)};
+    {{Class, Reason}, parse_stacktrace(Stacktrace)};
 parse_reason({Reason, Stacktrace}) ->
-	case is_elixir() of
-		false ->
-			{{exit, Reason}, parse_stacktrace(Stacktrace)};
-		_ ->
-			parse_reason_ex(Reason)
-	end;
+    case is_elixir() of
+        false ->
+            {{exit, Reason}, parse_stacktrace(Stacktrace)};
+        _ ->
+            parse_reason_ex(Reason)
+    end;
 parse_reason(Reason) ->
-	{{exit, Reason}, []}.
+    {{exit, Reason}, []}.
 
 %% @private
 parse_stacktrace({_, _, _} = MFA) -> [MFA];
@@ -389,12 +389,12 @@ parse_stacktrace(_) -> [].
 
 %% @private
 parse_reason_ex({Reason, Stacktrace}) ->
-	case 'Elixir.Exception':'exception?'(Reason) of
-		false ->
-			{{exit, Reason}, parse_stacktrace(Stacktrace)};
-		true ->
-			{{exit, format_message_ex(Reason)}, parse_stacktrace(Stacktrace)}
-	end.
+    case 'Elixir.Exception':'exception?'(Reason) of
+        false ->
+            {{exit, Reason}, parse_stacktrace(Stacktrace)};
+        true ->
+            {{exit, format_message_ex(Reason)}, parse_stacktrace(Stacktrace)}
+    end.
 
 %% @private
 format_message_ex(Reason) -> 'Elixir.Exception':message(Reason).
@@ -404,9 +404,9 @@ format_message_ex(Reason) -> 'Elixir.Exception':message(Reason).
 
 %% @private
 format_exit(Tag, Name, Reason) when is_pid(Name) ->
-	format("~s terminated with reason: ~s", [Tag, format_reason(Reason)]);
+    format("~s terminated with reason: ~s", [Tag, format_reason(Reason)]);
 format_exit(Tag, Name, Reason) ->
-	format("~s ~s terminated with reason: ~s", [Tag, format_name(Name), format_reason(Reason)]).
+    format("~s ~s terminated with reason: ~s", [Tag, format_name(Name), format_reason(Reason)]).
 
 %% @private
 format_name({local, Name}) -> Name;
@@ -416,80 +416,80 @@ format_name(Name) -> format_string(Name).
 
 %% @private
 format_reason({'function not exported', Trace}) ->
-	["call to undefined function ", format_mfa(Trace)];
+    ["call to undefined function ", format_mfa(Trace)];
 format_reason({undef, Trace}) ->
-	["call to undefined function ", format_mfa(Trace)];
+    ["call to undefined function ", format_mfa(Trace)];
 format_reason({bad_return, {_MFA, {'EXIT', Reason}}}) ->
-	format_reason(Reason);
+    format_reason(Reason);
 format_reason({bad_return, {Trace, Val}}) ->
-	["bad return value ", format_term(Val), " from ", format_mfa(Trace)];
+    ["bad return value ", format_term(Val), " from ", format_mfa(Trace)];
 format_reason({bad_return_value, Val}) ->
-	["bad return value ", format_term(Val)];
+    ["bad return value ", format_term(Val)];
 format_reason({{bad_return_value, Val}, Trace}) ->
-	["bad return value ", format_term(Val), " in ", format_mfa(Trace)];
+    ["bad return value ", format_term(Val), " in ", format_mfa(Trace)];
 format_reason({{badrecord, Record}, Trace}) ->
-	["bad record ", format_term(Record), " in ", format_mfa(Trace)];
+    ["bad record ", format_term(Record), " in ", format_mfa(Trace)];
 format_reason({{case_clause, Value}, Trace}) ->
-	["no case clause matching ", format_term(Value), " in ", format_mfa(Trace)];
+    ["no case clause matching ", format_term(Value), " in ", format_mfa(Trace)];
 format_reason({function_clause, Trace}) ->
-	["no function clause matching ", format_mfa(Trace)];
+    ["no function clause matching ", format_mfa(Trace)];
 format_reason({if_clause, Trace}) ->
-	["no true branch found while evaluating if expression in ", format_mfa(Trace)];
+    ["no true branch found while evaluating if expression in ", format_mfa(Trace)];
 format_reason({{try_clause, Value}, Trace}) ->
-	["no try clause matching ", format_term(Value), " in ", format_mfa(Trace)];
+    ["no try clause matching ", format_term(Value), " in ", format_mfa(Trace)];
 format_reason({badarith, Trace}) ->
-	["bad arithmetic expression in ", format_mfa(Trace)];
+    ["bad arithmetic expression in ", format_mfa(Trace)];
 format_reason({{badmatch, Value}, Trace}) ->
-	["no match of right hand value ", format_term(Value), " in ", format_mfa(Trace)];
+    ["no match of right hand value ", format_term(Value), " in ", format_mfa(Trace)];
 format_reason({emfile, _Trace}) ->
-	"maximum number of file descriptors exhausted, check ulimit -n";
+    "maximum number of file descriptors exhausted, check ulimit -n";
 format_reason({system_limit, [{M, F, _}|_] = Trace}) ->
-	Limit = case {M, F} of
-		{erlang, open_port} ->
-			"maximum number of ports exceeded";
-		{erlang, spawn} ->
-			"maximum number of processes exceeded";
-		{erlang, spawn_opt} ->
-			"maximum number of processes exceeded";
-		{erlang, list_to_atom} ->
-			"tried to create an atom larger than 255, or maximum atom count exceeded";
-		{ets, new} ->
-			"maximum number of ETS tables exceeded";
-		_ ->
-			format_mfa(Trace)
-	end,
-	["system limit: ", Limit];
+    Limit = case {M, F} of
+        {erlang, open_port} ->
+            "maximum number of ports exceeded";
+        {erlang, spawn} ->
+            "maximum number of processes exceeded";
+        {erlang, spawn_opt} ->
+            "maximum number of processes exceeded";
+        {erlang, list_to_atom} ->
+            "tried to create an atom larger than 255, or maximum atom count exceeded";
+        {ets, new} ->
+            "maximum number of ETS tables exceeded";
+        _ ->
+            format_mfa(Trace)
+    end,
+    ["system limit: ", Limit];
 format_reason({badarg, Trace}) ->
-	["bad argument in ", format_mfa(Trace)];
+    ["bad argument in ", format_mfa(Trace)];
 format_reason({{badarity, {Fun, Args}}, Trace}) ->
-	{arity, Arity} = lists:keyfind(arity, 1, erlang:fun_info(Fun)),
-	[io_lib:format("fun called with wrong arity of ~w instead of ~w in ", [length(Args), Arity]), format_mfa(Trace)];
+    {arity, Arity} = lists:keyfind(arity, 1, erlang:fun_info(Fun)),
+    [io_lib:format("fun called with wrong arity of ~w instead of ~w in ", [length(Args), Arity]), format_mfa(Trace)];
 format_reason({noproc, Trace}) ->
-	["no such process or port in call to ", format_mfa(Trace)];
+    ["no such process or port in call to ", format_mfa(Trace)];
 format_reason({{badfun, Term}, Trace}) ->
-	["bad function ", format_term(Term), " in ", format_mfa(Trace)];
+    ["bad function ", format_term(Term), " in ", format_mfa(Trace)];
 format_reason({#{'__exception__' := true} = Reason, Stacktrace}) ->
   [format_message_ex(Reason), 'Elixir.Exception':format_stacktrace(Stacktrace)];
 format_reason({Reason, {M, F, A} = Trace}) when is_atom(M), is_atom(F), is_list(A) ->
   [format_reason(Reason), " in ", format_mfa(Trace)];
 format_reason({Reason, [{M, F, A}|_] = Trace}) when is_atom(M), is_atom(F), is_integer(A) ->
-	[format_reason(Reason), " in ", format_mfa(Trace)];
+    [format_reason(Reason), " in ", format_mfa(Trace)];
 format_reason({Reason, [{M, F, A, Props}|_] = Trace}) when is_atom(M), is_atom(F), is_integer(A), is_list(Props) ->
-	[format_reason(Reason), " in ", format_mfa(Trace)];
+    [format_reason(Reason), " in ", format_mfa(Trace)];
 format_reason(Reason) ->
-	format_term(Reason).
+    format_term(Reason).
 
 %% @private
 format_mfa([{_, _, _} = MFA | _]) ->
-	format_mfa(MFA);
+    format_mfa(MFA);
 format_mfa([{_, _, _, _} = MFA | _]) ->
-	format_mfa(MFA);
+    format_mfa(MFA);
 format_mfa({M, F, A, _}) ->
-	format_mfa({M, F, A});
+    format_mfa({M, F, A});
 format_mfa({M, F, A}) ->
-	format_mfa_platform({M, F, A});
+    format_mfa_platform({M, F, A});
 format_mfa(Term) ->
-	format_term(Term).
+    format_term(Term).
 
 %% @private
 format_mfa_platform({M, F, A} = MFA) ->
@@ -501,33 +501,33 @@ format_mfa_platform({M, F, A} = MFA) ->
 %% @private
 format_mfa_erlang({M, F, A}) when is_list(A) ->
   {Format, Args} = format_args(A, [], []),
-	format("~w:~w(" ++ Format ++ ")", [M, F | Args]);
+    format("~w:~w(" ++ Format ++ ")", [M, F | Args]);
 format_mfa_erlang({M, F, A}) when is_integer(A) ->
   format("~w:~w/~w", [M, F, A]).
 
 %% @private
 format_args([], FormatAcc, ArgsAcc) ->
-	{string:join(lists:reverse(FormatAcc), ", "), lists:reverse(ArgsAcc)};
+    {string:join(lists:reverse(FormatAcc), ", "), lists:reverse(ArgsAcc)};
 format_args([Arg | Rest], FormatAcc, ArgsAcc) ->
-	format_args(Rest, ["~s" | FormatAcc], [format_term(Arg) | ArgsAcc]).
+    format_args(Rest, ["~s" | FormatAcc], [format_term(Arg) | ArgsAcc]).
 
 %% @private
 format_string(Term) when is_atom(Term); is_binary(Term) ->
-	format("~s", [Term]);
+    format("~s", [Term]);
 format_string(Term) ->
-	try format("~s", [Term]) of
-		Result -> Result
-	catch
-		error:badarg -> format_term(Term)
-	end.
+    try format("~s", [Term]) of
+        Result -> Result
+    catch
+        error:badarg -> format_term(Term)
+    end.
 
 %% @private
 format_term(Term) ->
-	format("~120p", [Term]).
+    format("~120p", [Term]).
 
 %% @private
 format(Format, Data) ->
-	iolist_to_binary(io_lib:format(Format, Data)).
+    iolist_to_binary(io_lib:format(Format, Data)).
 
 %% @private
 is_elixir() ->

--- a/src/raven_error_logger_filter.erl
+++ b/src/raven_error_logger_filter.erl
@@ -1,0 +1,13 @@
+-module(raven_error_logger_filter).
+-include("raven_error_logger.hrl").
+
+-optional_callbacks([should_send_supervisor_report/3]).
+
+%% @doc OTP supervisors will generate an `error_report` every time
+%% a process is restarted, even if the shutdown is normal.
+%% To avoid spamming Sentry with issues that are not errors,
+%% one can implement this callback to filter supervisor reports,
+%% received from error logger.
+-callback should_send_supervisor_report(supervisor(),
+                                        reason(),
+                                        supervisor_report_context()) -> boolean().

--- a/src/raven_sup.erl
+++ b/src/raven_sup.erl
@@ -2,12 +2,12 @@
 -behaviour(supervisor).
 -export([
     start_link/0,
-	init/1
+    init/1
 ]).
 
 start_link() ->
-	supervisor:start_link({local, ?MODULE}, ?MODULE, []).
+    supervisor:start_link({local, ?MODULE}, ?MODULE, []).
 
 %% @hidden
 init([]) ->
-	{ok, {{one_for_one, 5, 10}, []}}.
+    {ok, {{one_for_one, 5, 10}, []}}.

--- a/test/raven_app_test.erl
+++ b/test/raven_app_test.erl
@@ -8,33 +8,33 @@
 %%%%%%%%%%%%%%%%%%%%%%%%%%
 
 load_configuration_test_() ->
-	[
-		{"Loads configuration from application env",
-		fun() ->
-			{StartAppStatus, _} = application:ensure_all_started(raven_erlang),
-			?assertEqual(ok, StartAppStatus),
-			Config = raven:get_config(),
-			{cfg,"https://app.getsentry.com","PUBLIC_KEY","PRIVATE_KEY","1",inet6} = Config,
-			ok = application:stop(raven_erlang)
-		end},
-		{"Loads a default value (inet) for ipfamily if not specified",
-		fun() ->
-			ok = application:unset_env(raven_erlang, ipfamily),
-			{StartAppStatus, _} = application:ensure_all_started(raven_erlang),
-			?assertEqual(ok, StartAppStatus),
-			Config = raven:get_config(),
-			{cfg,"https://app.getsentry.com","PUBLIC_KEY","PRIVATE_KEY","1",inet} = Config,
-			ok = application:stop(raven_erlang)
-		end}
-	].
+    [
+        {"Loads configuration from application env",
+        fun() ->
+            {StartAppStatus, _} = application:ensure_all_started(raven_erlang),
+            ?assertEqual(ok, StartAppStatus),
+            Config = raven:get_config(),
+            {cfg,"https://app.getsentry.com","PUBLIC_KEY","PRIVATE_KEY","1",inet6} = Config,
+            ok = application:stop(raven_erlang)
+        end},
+        {"Loads a default value (inet) for ipfamily if not specified",
+        fun() ->
+            ok = application:unset_env(raven_erlang, ipfamily),
+            {StartAppStatus, _} = application:ensure_all_started(raven_erlang),
+            ?assertEqual(ok, StartAppStatus),
+            Config = raven:get_config(),
+            {cfg,"https://app.getsentry.com","PUBLIC_KEY","PRIVATE_KEY","1",inet} = Config,
+            ok = application:stop(raven_erlang)
+        end}
+    ].
 
 capture_event_test_() ->
-	[
-		{"We can start the app and capture a simple event",
-		fun() ->
-			{StartAppStatus, _} = application:ensure_all_started(raven_erlang),
-			?assertEqual(ok, StartAppStatus),
-			ok = raven:capture("Test event", []),
-			ok = application:stop(raven_erlang)
-		end}
-	].
+    [
+        {"We can start the app and capture a simple event",
+        fun() ->
+            {StartAppStatus, _} = application:ensure_all_started(raven_erlang),
+            ?assertEqual(ok, StartAppStatus),
+            ok = raven:capture("Test event", []),
+            ok = application:stop(raven_erlang)
+        end}
+    ].


### PR DESCRIPTION
Hi, Yuri!

I made some improvements to `raven_error_logger` which I think are worth sharing:
- Make sure that raven_error_logger does not crash on unexpected report type
  
  Error logger can pass literally anything, depending on what it was called with.
- Allow customizing raven_error_logger behavior

  Some supervisor reports are not errors, and indicate normal termination of a child.
  I added a config option to selectively ignore them and avoid spamming sentry.
- Convert a mix of tabs and spaces to spaces

  I noticed that a mix of 4-width tabs and spaces was used, decided to convert to spaces to avoid alignment issues. Can revert this one if you prefer tabs.
- Use proplists:get_value() instead of pattern matching on the result of lists:sort()
  
  Potentially safer/faster.

I tested the changes locally and updated `README.md`. I also bumped the app version.
What do you think?
