### PR TITLE
update jsone to version 1.4.6 to support OTP-21

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,3 +7,4 @@ script:
 otp_release:
 - 20.1
 - 20.0
+- 21.0

--- a/rebar.config
+++ b/rebar.config
@@ -6,4 +6,4 @@
 	{platform_define, "^R14", no_callbacks}
 ]}.
 {plugins, [rebar3_hex]}.
-{deps, [{jsone, "1.2.3"}]}.
+{deps, [{jsone, "1.4.6"}]}.

--- a/rebar.lock
+++ b/rebar.lock
@@ -1,6 +1,6 @@
 {"1.1.0",
-[{<<"jsone">>,{pkg,<<"jsone">>,<<"1.2.3">>},0}]}.
+[{<<"jsone">>,{pkg,<<"jsone">>,<<"1.4.6">>},0}]}.
 [
 {pkg_hash,[
- {<<"jsone">>, <<"D2E9979326BDAACF50AB0E52C80F53D74CDED93D1AE21FABCF66346238CC0322">>}]}
+ {<<"jsone">>, <<"644D6D57BEFB22C8E19B324DEE19D73B1C004565009861A8F64C68B7B9E64DBF">>}]}
 ].


### PR DESCRIPTION
without this change raven-erlang will not compile using erlang otp-21

```
===> Compiling _build/default/lib/jsone/src/jsone.erl failed
_build/default/lib/jsone/src/jsone.erl:218: erlang:get_stacktrace/0: deprecated; use the new try/catch syntax for retrieving the stack backtrace
_build/default/lib/jsone/src/jsone.erl:267: erlang:get_stacktrace/0: deprecated; use the new try/catch syntax for retrieving the stack backtrace

```