### PR TITLE
using git source for jsone, not package

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -5,5 +5,7 @@
 	warn_export_all,
 	{platform_define, "^R14", no_callbacks}
 ]}.
-{plugins, [rebar3_hex]}.
-{deps, [{jsone, "1.4.6"}]}.
+{plugins, []}.
+{deps, [
+        {jsone, {git, "git://github.com/sile/jsone.git", {tag, "1.4.6"}}}
+]}.

--- a/rebar.lock
+++ b/rebar.lock
@@ -1,6 +1,4 @@
-{"1.1.0",
-[{<<"jsone">>,{pkg,<<"jsone">>,<<"1.4.6">>},0}]}.
-[
-{pkg_hash,[
- {<<"jsone">>, <<"644D6D57BEFB22C8E19B324DEE19D73B1C004565009861A8F64C68B7B9E64DBF">>}]}
-].
+[{<<"jsone">>,
+  {git,"git://github.com/sile/jsone.git",
+       {ref,"b23d312a5ed051ea7ad0989a9f2cb1a9c3f9a502"}},
+  0}].


### PR DESCRIPTION
Hi, @artemeff 

When we use jsone like a package

```
{jsone, "1.4.6"}
```

we need to download from hex.pm (and then use cached artefact):
- rebar3_hex
- hex_core
- verl

As I understand, in closed infrastructure for using **raven-erlang** I need to set up mine cdn for that packages:

```
{rebar_packages_cdn, "https://"}
```

So, I think, better way is using git source url, because I don't need connection to hex & +3 deps for using **jsone**.

Thanks!