### PR TITLE
Allow usage of new DSNs, without a private key

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,3 +2,4 @@
 
 test:
 	ERL_FLAGS="-config ./test/conf/sample.config" rebar3 eunit
+	ERL_FLAGS="-config ./test/conf/deprecated_dsn.config" rebar3 eunit

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ In `rebar.config`:
 
 ```erlang
 {deps, [
-    {raven_erlang, "0.4.0"}
+    {raven_erlang, "0.4.3"}
 ]}.
 ```
 
@@ -40,10 +40,11 @@ To start `raven_erlang` with your application, add in your `myapp.app.src`:
     {uri, "https://app.getsentry.com"},
     {project, "1"},
     {public_key, "PUBLIC_KEY"},
-    {private_key, "PRIVATE_KEY"},
+    {private_key, "PRIVATE_KEY"},  % This is now optional
 
     % ...or just use the DSN:
-    {dsn, "https://PUBLIC_KEY:PRIVATE_KEY@app.getsentry.com/1"},
+    {dsn, "https://PUBLIC_KEY@app.getsentry.com/1"},
+    % {dsn, "https://PUBLIC_KEY:PRIVATE_KEY@app.getsentry.com/1"},  % If using the private key
 
     % Set to inet6 to use IPv6.
     % See `ipfamily` in `httpc:set_options/1` for more information.
@@ -118,12 +119,15 @@ To exclude all metadata except `pid`:
 You can log directly events to sentry using the `raven:capture/2` function, for example:
 
 ```erlang
-raven:capture("Test Event", [
-    {exception, {error, badarg}},
-    {stacktrace, erlang:get_stacktrace()},
-    {extra, [
-        {pid, self()},
-        {process_dictionary, erlang:get()}
-    ]}
-]).
+try erlang:error(badarg)
+catch Class:Reason:Stacktrace ->
+    raven:capture("Test Event", [
+        {exception, {Class, Reason}},
+        {stacktrace, Stacktrace},
+        {extra, [
+            {pid, self()},
+            {process_dictionary, erlang:get()}
+        ]}
+    ])
+end.
 ```

--- a/src/raven.erl
+++ b/src/raven.erl
@@ -106,11 +106,17 @@ get_config(App) ->
     IpFamily = application:get_env(App, ipfamily, inet),
     case application:get_env(App, dsn) of
         {ok, Dsn} ->
-            {match, [_, Protocol, PublicKey, SecretKey, Uri, Project]} =
-                re:run(Dsn, "^(https?://)(.+):(.+)@(.+)/(.+)$", [{capture, all, list}]),
+            {match, [_, Protocol, Keys, Uri, Project]} =
+                re:run(Dsn, "^(https?://)(.+)@(.+)/(.+)$", [{capture, all, list}]),
+            [PublicKey | MaybePrivateKey] = string:split(Keys, ":"),
+            PrivateKey =
+                case MaybePrivateKey of
+                    [] -> "";
+                    [Key] -> Key
+                end,
             #cfg{uri = Protocol ++ Uri,
                  public_key = PublicKey,
-                 private_key = SecretKey,
+                 private_key = PrivateKey,
                  project = Project,
                  ipfamily = IpFamily};
         undefined ->

--- a/src/raven_erlang.app.src
+++ b/src/raven_erlang.app.src
@@ -1,6 +1,6 @@
 {application, raven_erlang,
     [ {description, "Erlang client for Sentry"}
-    , {vsn, "0.4.2"}
+    , {vsn, "0.4.3"}
     , {registered, []}
     , {applications, [kernel, stdlib, crypto, public_key, ssl, inets, jsone]}
     , {mod, {raven_app, []}}

--- a/test/conf/deprecated_dsn.config
+++ b/test/conf/deprecated_dsn.config
@@ -1,6 +1,6 @@
 [
   {raven_erlang, [
-      {dsn, "https://PUBLIC_KEY@app.getsentry.com/1"},
+      {dsn, "https://PUBLIC_KEY:PRIVATE_KEY@app.getsentry.com/1"},
       {error_logger, true},  % Set to true in order to install the standard error logger
       {ipfamily, inet6}
   ]}

--- a/test/raven_app_test.erl
+++ b/test/raven_app_test.erl
@@ -14,7 +14,8 @@ load_configuration_test_() ->
             {StartAppStatus, _} = application:ensure_all_started(raven_erlang),
             ?assertEqual(ok, StartAppStatus),
             Config = raven:get_config(),
-            {cfg,"https://app.getsentry.com","PUBLIC_KEY","PRIVATE_KEY","1",inet6} = Config,
+            {cfg,"https://app.getsentry.com","PUBLIC_KEY",PrivateKey,"1",inet6} = Config,
+            ?assert(PrivateKey == "PRIVATE_KEY" orelse PrivateKey == ""),
             ok = application:stop(raven_erlang)
         end},
         {"Loads a default value (inet) for ipfamily if not specified",
@@ -23,7 +24,8 @@ load_configuration_test_() ->
             {StartAppStatus, _} = application:ensure_all_started(raven_erlang),
             ?assertEqual(ok, StartAppStatus),
             Config = raven:get_config(),
-            {cfg,"https://app.getsentry.com","PUBLIC_KEY","PRIVATE_KEY","1",inet} = Config,
+            {cfg,"https://app.getsentry.com","PUBLIC_KEY",PrivateKey,"1",inet} = Config,
+            ?assert(PrivateKey == "PRIVATE_KEY" orelse PrivateKey == ""),
             ok = application:stop(raven_erlang)
         end}
     ].


### PR DESCRIPTION
Since the last version of raven-erlang, Sentry has soft-deprecated the use of private keys as part of DSN URLs. Now just using the public key works from the Sentry side. But raven-erlang currently assumes the config uses the old version of the DSN, with a colon separating the public and private key. This pull request allows for either form of the DSN to be used, considering that projects starting to use Sentry from the time of the DSN change will likely get the new version from the Sentry website and encounter errors due to the lack of the colon in that DSN.

This also updates the recommended usage of `raven:capture/2` in the documentation, since the current version uses the OTP-deprecated `erlang:get_stacktrace/0`.