### PR TITLE
use 0 not -1 for absent line numbers, to pacify Sentry

### DIFF
--- a/src/raven.erl
+++ b/src/raven.erl
@@ -162,7 +162,7 @@ frame_to_json_i({Module, Function, Arguments, Location}) ->
         false -> Arguments
     end,
     Line = case lists:keyfind(line, 1, Location) of
-        false -> -1;
+        false -> 0;
         {line, L} -> L
     end,
     {


### PR DESCRIPTION
Fixes the following error which we got a lot of from Sentry:
```
Sentry has identified the following problems for you to fix
Discarded invalid value(2)
Name stacktrace.frames.2.lineno
Reason expected an unsigned integer
Value -1
```