### PR TITLE
pass verify_none to httpc:request

### DIFF
--- a/src/raven.erl
+++ b/src/raven.erl
@@ -84,9 +84,10 @@ capture(Message, Params0) ->
         {"User-Agent", UA}
     ],
     ok = httpc:set_options([{ipfamily, Cfg#cfg.ipfamily}]),
+    HttpOptions = [{ssl, [{verify, verify_none}]}],
     httpc:request(post,
         {Cfg#cfg.uri ++ "/api/store/", Headers, "application/octet-stream", Body},
-        [],
+        HttpOptions,
         [{body_format, binary}, {sync, false}, {receiver, fun(_) -> ok end}]
     ),
     ok.


### PR DESCRIPTION
The `ssl` changes in OTP-26 mean that any code that doesn't specify `verify_none` will default to `verify_peer`, and unless certs are passed in you get hard errors. This also affects `httpc:request`. Update uses of the latter to explicitly pass in `verify_none`.